### PR TITLE
Pass full request through instead of just the `data` object

### DIFF
--- a/R/reroute.R
+++ b/R/reroute.R
@@ -11,9 +11,6 @@ reroute <- function(req, res) {
       new_path <- body$script
       if (!startsWith(new_path, "/")) new_path <- paste0("/", new_path)
       req$PATH_INFO <- new_path
-
-      # Update the body of the request
-      req$postBody <- jsonlite::toJSON(body$data)
     }
   }
   plumber::forward()


### PR DESCRIPTION
This rolls back a previous change as a result of the RStudio Connect build. Now, the full request object from Tableau is forwarded to the requested endpoint, rather than just the `data` object of the request.