### PR TITLE
Squelch log messages during unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ URL: https://rstudio.github.io/plumbertableau/, https://github.com/rstudio/plumb
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    plumber,
+    plumber (>= 1.0.0.90001),
     magrittr,
     curl,
     httpuv,
@@ -29,5 +29,7 @@ Suggests:
     zeallot,
     knitr,
     rmarkdown
+Remotes:
+    rstudio/plumber
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/client.R
+++ b/R/client.R
@@ -75,13 +75,7 @@ tableau_invoke <- function(pr, script, ..., .toJSON_args = NULL) {
   # In case of error
   on.exit(later_handle(), add = TRUE)
 
-  # TODO: Suppress messages during plumber startup. Ideally this would be with
-  # a `quiet = TRUE` argument to `run()` or `options_plumber(quiet = TRUE)`, but
-  # if necessary, we could use `sink()` to squelch messages before `run()` and
-  # unsquelch them as soon as our `later()` callback above begins executing.
-  # If we go with the latter approach, we'll need to watch out for the case
-  # where the later callback was never called.
-  pr$run(port = port)
+  pr$run(port = port, quiet = TRUE, swaggerCallback = NULL)
 
   if (is_error) {
     stop(result)


### PR DESCRIPTION
New version of plumber is required because `quiet = TRUE` is new. plumber should be going to CRAN soon, so we shouldn't need to keep the Remotes field in our DESCRIPTION for long.