### PR TITLE
Add context about Tableau Analytics Extensions to the user guide

### DIFF
--- a/R/user_guide.R
+++ b/R/user_guide.R
@@ -37,6 +37,9 @@ render_user_guide <- function(path, pr) {
         title,
         if (!is.null(version)) paste0("(v", version, ")")
       ),
+      tags$h3(
+        "A Tableau Analytics Extension"
+      ),
       tags$div(class = "api-desc",
         desc
       )


### PR DESCRIPTION
This is an initial pass at adding some additional context to the user guide. We'll probably want more context than this, but it's a start.