### PR TITLE
Update validate_request to handle tableau_arg_spec objects

### DIFF
--- a/R/validate_request.R
+++ b/R/validate_request.R
@@ -28,11 +28,7 @@ validate_request <- function(req, ...) {
 
   # Check to make sure data types match
   dat_types <- lapply(dat, class)
-  mismatch <- unlist(
-    Map(function(x, y) x != y,
-        val,
-        dat_types)
-  )
+  mismatch <- check_types(val, dat_types)
   if (any(mismatch)) {
     err <- paste0("Mismatched data types found in ",
                   req$PATH_INFO,
@@ -56,4 +52,17 @@ validate_request <- function(req, ...) {
 
   # Return the renamed data as a list
   dat
+}
+
+# Check expected data types against actual data types
+check_types <- function(expected_types, actual_types) {
+  unlist(
+    Map(function(x, y) {
+      if (class(x) == "tableau_arg_spec") {
+        x$type != y
+      } else {
+        x != y
+      }
+    })
+  )
 }


### PR DESCRIPTION
This fixes a bug that caused endpoints that used `arg_spec()` to fail with odd errors. The bug was due to the fact that we were checking for a straight match between the expected data type and the provided data type. This works when `arg_spec()` isn't used, because the definition of expected types is just a list. However, when `arg_spec()` is used, the resulting list is a list of `tableau_arg_spec` objects, which need to be compared differently.
