### PR TITLE
Create testing skeleton and add Codecov

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 /rsconnect$
 ^notes\.md$
 ^\.Renviron$
+^codecov\.yml$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,6 +68,7 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Check
@@ -84,3 +85,8 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
+
+      - name: Test coverage
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ RoxygenNote: 7.1.1
 Suggests: 
     testthat (>= 3.0.0),
     knitr,
-    rmarkdown
+    rmarkdown,
+    covr
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,0 +1,1 @@
+pr_path <- system.file("examples/stringutils/plumber.R", package = "plumbertableau")

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,1 +1,1 @@
-pr_path <- system.file("examples/stringutils/plumber.R", package = "plumbertableau")
+pr_path <- function() system.file("examples/stringutils/plumber.R", package = "plumbertableau")

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/rstudio/plumbertableau/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/plumbertableau/actions)
+[![Codecov test coverage](https://codecov.io/gh/rstudio/plumbertableau/branch/main/graph/badge.svg)](https://codecov.io/gh/rstudio/plumbertableau?branch=main)
 <!-- badges: end -->
 
 An R package that helps create [Plumber APIs](https://www.rplumber.io/) that are

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -1,5 +1,3 @@
-pr_path <- system.file("examples/stringutils/plumber.R", package = "plumbertableau")
-
 test_that("debug logging works", {
 
 })

--- a/tests/testthat/test-error_handler.R
+++ b/tests/testthat/test-error_handler.R
@@ -1,6 +1,11 @@
 test_that("error_handler returns correct object", {
-  # TODO: Check error_handler itself, don't invoke full router
-  skip("not implemented")
-  res <- list()
-  error_handler(res = res, err = )
+  req <- as.environment(list())
+  res <- as.environment(list())
+  err <- rlang::catch_cnd(stop("This is an error"))
+  handled_err <- error_handler(req = req, res = res, err = err)
+  expect_equal(handled_err, list(
+    message = jsonlite::unbox("Server Error"),
+    info = jsonlite::unbox("This is an error")
+  ))
+  expect_equal(res$status, 500)
 })

--- a/tests/testthat/test-error_handler.R
+++ b/tests/testthat/test-error_handler.R
@@ -1,0 +1,6 @@
+test_that("error_handler returns correct object", {
+  # TODO: Check error_handler itself, don't invoke full router
+  skip("not implemented")
+  res <- list()
+  error_handler(res = res, err = )
+})

--- a/tests/testthat/test-info.R
+++ b/tests/testthat/test-info.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})

--- a/tests/testthat/test-openapi.R
+++ b/tests/testthat/test-openapi.R
@@ -1,5 +1,5 @@
 test_that("OpenAPI specification works", {
-  pr <- plumber::plumb(pr_path)
+  pr <- plumber::plumb(pr_path())
   spec <- pr$getApiSpec()
   for (path in spec$paths) {
     if (!is.null(path$post)) {

--- a/tests/testthat/test-openapi.R
+++ b/tests/testthat/test-openapi.R
@@ -1,0 +1,9 @@
+test_that("OpenAPI specification works", {
+  pr <- plumber::plumb(pr_path)
+  spec <- pr$getApiSpec()
+  for (path in spec$paths) {
+    if (!is.null(path$post)) {
+      expect_equal(path$post$requestBody$description, "Tableau Request")
+    }
+  }
+})

--- a/tests/testthat/test-reroute.R
+++ b/tests/testthat/test-reroute.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})

--- a/tests/testthat/test-rsc_filter.R
+++ b/tests/testthat/test-rsc_filter.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})

--- a/tests/testthat/test-tableau_extension.R
+++ b/tests/testthat/test-tableau_extension.R
@@ -38,28 +38,8 @@ test_that("stringutils example works", {
   expect_error(tableau_invoke(pr_path, "/concat", letters, seq_along(letters), .quiet = TRUE))
 })
 
-test_that("OpenAPI specification works", {
-  pr <- plumber::plumb(pr_path)
-  spec <- pr$getApiSpec()
-  for (path in spec$paths) {
-    if (!is.null(path$post)) {
-      expect_equal(path$post$requestBody$description, "Tableau Request")
-    }
-  }
-})
-
-test_that("tableau_handler warns on missing function params", {
-  args <- list(foo = arg_spec("character"), bar = arg_spec("character"))
-
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function() {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(foo) {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(bar) {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(foo, bar) {}), NA)
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(...) {}), NA)
-
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res) {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, foo) {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, bar) {}))
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, foo, bar) {}), NA)
-  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, ...) {}), NA)
+test_that("error_handler returns correct object", {
+  # TODO: Check error_handler itself, don't invoke full router
+  res <- list()
+  error_handler(res = res, err = )
 })

--- a/tests/testthat/test-tableau_extension.R
+++ b/tests/testthat/test-tableau_extension.R
@@ -1,5 +1,3 @@
-pr_path <- system.file("examples/stringutils/plumber.R", package = "plumbertableau")
-
 test_that("stringutils example works", {
 
   expect_identical(
@@ -36,10 +34,4 @@ test_that("stringutils example works", {
   expect_error(tableau_invoke(pr_path, "/concat", letters, letters, letters, .quiet = TRUE))
   # Incorrect data type
   expect_error(tableau_invoke(pr_path, "/concat", letters, seq_along(letters), .quiet = TRUE))
-})
-
-test_that("error_handler returns correct object", {
-  # TODO: Check error_handler itself, don't invoke full router
-  res <- list()
-  error_handler(res = res, err = )
 })

--- a/tests/testthat/test-tableau_extension.R
+++ b/tests/testthat/test-tableau_extension.R
@@ -1,37 +1,37 @@
 test_that("stringutils example works", {
 
   expect_identical(
-    tableau_invoke(pr_path, "/lowercase", "HELLO"),
+    tableau_invoke(pr_path(), "/lowercase", "HELLO"),
     "hello"
   )
 
   expect_identical(
-    tableau_invoke(pr_path, "/concat", letters, LETTERS),
+    tableau_invoke(pr_path(), "/concat", letters, LETTERS),
     paste0(letters, " ", LETTERS)
   )
 
   expect_identical(
-    tableau_invoke(pr_path, "/concat?sep=-", letters, LETTERS),
+    tableau_invoke(pr_path(), "/concat?sep=-", letters, LETTERS),
     paste0(letters, "-", LETTERS)
   )
 
   expect_identical(
-    tableau_invoke(pr_path, "/stringify", 1:10),
+    tableau_invoke(pr_path(), "/stringify", 1:10),
     as.character(1:10)
   )
 
   expect_identical(
-    tableau_invoke(pr_path, "/stringify", c(TRUE, FALSE, NA, TRUE)),
+    tableau_invoke(pr_path(), "/stringify", c(TRUE, FALSE, NA, TRUE)),
     c("true", "false", NA, "true")
   )
 
   # 404
-  expect_error(tableau_invoke(pr_path, "/blah", .quiet = TRUE))
+  expect_error(tableau_invoke(pr_path(), "/blah", .quiet = TRUE))
   # Too few args
-  expect_error(tableau_invoke(pr_path, "/concat", letters, .quiet = TRUE))
-  expect_error(tableau_invoke(pr_path, "/stringify", .quiet = TRUE))
+  expect_error(tableau_invoke(pr_path(), "/concat", letters, .quiet = TRUE))
+  expect_error(tableau_invoke(pr_path(), "/stringify", .quiet = TRUE))
   # Too many args
-  expect_error(tableau_invoke(pr_path, "/concat", letters, letters, letters, .quiet = TRUE))
+  expect_error(tableau_invoke(pr_path(), "/concat", letters, letters, letters, .quiet = TRUE))
   # Incorrect data type
-  expect_error(tableau_invoke(pr_path, "/concat", letters, seq_along(letters), .quiet = TRUE))
+  expect_error(tableau_invoke(pr_path(), "/concat", letters, seq_along(letters), .quiet = TRUE))
 })

--- a/tests/testthat/test-tableau_handler.R
+++ b/tests/testthat/test-tableau_handler.R
@@ -1,0 +1,15 @@
+test_that("tableau_handler warns on missing function params", {
+  args <- list(foo = arg_spec("character"), bar = arg_spec("character"))
+
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function() {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(foo) {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(bar) {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(foo, bar) {}), NA)
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(...) {}), NA)
+
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res) {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, foo) {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, bar) {}))
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, foo, bar) {}), NA)
+  expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, ...) {}), NA)
+})

--- a/tests/testthat/test-validate_request.R
+++ b/tests/testthat/test-validate_request.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})


### PR DESCRIPTION
This pull request contains the following:

- We added a testing skeleton — corresponding `test_*.R` files for each main file that needs testing.
- We wrote a few tests, exploring ways to create example request, response, and error objects for use with tests.
- We added Codecov to the main GitHub Actions workflow and the README. The badge won't show anything till this is on `main`.