### PR TITLE
Better programmatic development of Tableau extensions

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -3,7 +3,7 @@
 #' Simulates invoking a Tableau extension function from a Tableau calculated
 #' field `SCRIPT_*` call. Intended for unit testing of Tableau extension APIs.
 #'
-#' @param pr Either a [tableau_extension()] style Plumber router object, or, the
+#' @param pr Either a [tableau_extension] style Plumber router object, or, the
 #'   filename of a plumber.R that implements a Tableau extension.
 #' @param script The script string that identifies the plumber route to invoke.
 #'   (Equivalent to the first argument to `SCRIPT_STR`, et al., in Tableau.) URL

--- a/R/tableau_extension.R
+++ b/R/tableau_extension.R
@@ -1,9 +1,9 @@
 #' Make an existing Plumber API compliant as a Tableau Analytics Extension
 #'
-#' @param warnings Whether or not to provide warnings about non-Tableau compliant
-#' endpoints.
+#' @param pr A plumber router
 #'
-#' @return A function that can be used with \code{#* @plumber}
+#' @return A modified plumber router that functions as a Tableau Analytics
+#' Extension
 #'
 #' @examples
 #' \dontrun{
@@ -18,39 +18,39 @@
 #' }
 #'
 #' #* @plumber
-#' tableau_extension()
+#' tableau_extension
 #' }
 #'
 #' @export
-tableau_extension <- function(warnings = TRUE) {
-  function(pr) {
-    if (warnings) {
-      lapply(pr$routes, function(route) {
-        check_route(route)
-      })
-    }
-
-    # Infer Tableau handler information
-    lapply(pr$endpoints, function(routes) {
-      # Modify route in place
-      lapply(routes, function(route) {
-        route$.__enclos_env__$private$func <- infer_tableau_handler(route)
-      })
+tableau_extension <- function(pr) {
+  warnings <- getOption("plumbertableau.warnings", default = FALSE)
+  if (warnings) {
+    lapply(pr$routes, function(route) {
+      check_route(route)
     })
-
-    pr %>%
-      plumber::pr_get("/", create_user_guide(pr), serializer = plumber::serializer_html()) %>%
-      plumber::pr_static("/__plumbertableau_assets__",
-        system.file("www", package = "plumbertableau", mustWork = TRUE)) %>%
-      plumber::pr_filter("rsc_filter", rsc_filter) %>%
-      plumber::pr_filter("reroute", reroute) %>%
-      plumber::pr_hooks(list(
-        preroute = preroute_hook,
-        postroute = postroute_hook
-      )) %>%
-      plumber::pr_set_api_spec(tableau_openapi(pr)) %>%
-      plumber::pr_set_error(error_handler) %>%
-      plumber::pr_set_parsers("json") %>%
-      plumber::pr_set_serializer(plumber::serializer_unboxed_json())
   }
+
+  # Infer Tableau handler information
+  lapply(pr$endpoints, function(routes) {
+    # Modify route in place
+    lapply(routes, function(route) {
+      route$.__enclos_env__$private$func <- infer_tableau_handler(route)
+    })
+  })
+
+  pr %>%
+    plumber::pr_get("/", create_user_guide(pr), serializer = plumber::serializer_html()) %>%
+    plumber::pr_static("/__plumbertableau_assets__",
+                       system.file("www", package = "plumbertableau", mustWork = TRUE)) %>%
+    plumber::pr_filter("rsc_filter", rsc_filter) %>%
+    plumber::pr_filter("reroute", reroute) %>%
+    plumber::pr_hooks(list(
+      preroute = preroute_hook,
+      postroute = postroute_hook
+    )) %>%
+    plumber::pr_set_api_spec(tableau_openapi(pr)) %>%
+    plumber::pr_set_error(error_handler) %>%
+    plumber::pr_set_parsers("json") %>%
+    plumber::pr_set_serializer(plumber::serializer_unboxed_json())
 }
+

--- a/R/tableau_handler.R
+++ b/R/tableau_handler.R
@@ -10,7 +10,7 @@
 #'   `"numeric?"`.
 #' @param return A string indicating the data type that will be returned from
 #'   `func` (`"character"`, `"logical"`, `"numeric"`, or `"integer"`); or, a
-#'   specification object created by [arg_spec()].
+#'   specification object created by [return_spec()].
 #' @param func A function to be used as the handler function. Code in the body
 #'   of the function will automatically be able to access Tableau request args
 #'   simply by referring to their names in `args`; see the example below.

--- a/R/tableau_handler.R
+++ b/R/tableau_handler.R
@@ -124,11 +124,12 @@ infer_tableau_handler <- function(route) {
 
 
   # Check to see if Tableau args and return values have been provided
-  if (!("tab.arg" %in% parsed_comments$tag) | !("tab.return" %in% parsed_comments$tag)) {
-   stop(
-     call. = FALSE,
-     "Tableau argument and return data types must be specified. Please use either #* tab.arg and #* tab.return annotations or tableau_handler() to specify Tableau argument and return types."
-   )
+  err <- "Tableau argument and return data types must be specified. Please use either #* tab.arg and #* tab.return annotations or tableau_handler() to specify Tableau argument and return types."
+
+  if (rlang::is_empty(parsed_comments)) {
+    stop(err, call. = FALSE)
+  } else if (!("tab.arg" %in% parsed_comments$tag) | !("tab.return" %in% parsed_comments$tag)) {
+    stop(err, call. = FALSE)
   }
 
   args <- parsed_comments[parsed_comments$tag == c("tab.arg"), c("line", "remainder")]

--- a/R/tableau_handler.R
+++ b/R/tableau_handler.R
@@ -122,6 +122,15 @@ infer_tableau_handler <- function(route) {
   comment_lines_df <- get_comments_from_srcref(srcref)
   parsed_comments <- parse_comment_tags(comment_lines_df)
 
+
+  # Check to see if Tableau args and return values have been provided
+  if (!("tab.arg" %in% parsed_comments$tag) | !("tab.return" %in% parsed_comments$tag)) {
+   stop(
+     call. = FALSE,
+     "Tableau argument and return data types must be specified. Please use either #* tab.arg and #* tab.return annotations or tableau_handler() to specify Tableau argument and return types."
+   )
+  }
+
   args <- parsed_comments[parsed_comments$tag == c("tab.arg"), c("line", "remainder")]
   returns <- parsed_comments[parsed_comments$tag == c("tab.return"), c("line", "remainder")]
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,15 @@
 .onLoad <- function(libname, pkgname) {
+  # Debugging
   debugme::debugme()
+
+  # Options
+  op <- options()
+  op.plumbertableau <- list(
+    plumbertableau.warnings = TRUE
+  )
+
+  toset <- !(names(op.plumbertableau) %in% names(op))
+  if(any(toset)) options(op.plumbertableau[toset])
+
+  invisible()
 }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ remotes::install_github("rstudio/plumbertableau")
 ## Example
 
 The main function in `plumbertableau` is `tableau_extension()`. This function
-returns a function that takes an existing Plumber router and modifies it so that
-it complies with the specification set forward by the Tableau Analytics
-Extensions API.
+modifies an existing Plumber router so that it complies with the specification
+set forward by the Tableau Analytics Extensions API.
 
 ``` r
 library(plumber)
@@ -42,7 +41,7 @@ function(str_value) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension
 ```
 
 In order to use an analytics extension from Tableau, you need to configure the

--- a/inst/examples/loess/plumber.R
+++ b/inst/examples/loess/plumber.R
@@ -17,4 +17,4 @@ function(req, res, x, y, alpha = 0.75) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension

--- a/inst/examples/mounts/plumber.R
+++ b/inst/examples/mounts/plumber.R
@@ -11,4 +11,4 @@ function(pr) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension

--- a/inst/examples/programmatic/plumber.R
+++ b/inst/examples/programmatic/plumber.R
@@ -1,0 +1,23 @@
+library(plumber)
+library(plumbertableau)
+
+#* @plumber
+function(pr) {
+  pr %>%
+    pr_post("/capitalize", tableau_handler(
+      args = list(
+        str_value = arg_spec(
+          type = "character",
+          desc = "String(s) to be capitalized"
+        )
+      ),
+      return = return_spec(
+        type = "character",
+        desc = "Capitalized string(s)"
+      ),
+      func = function(str_value) {
+        toupper(str_value)
+      }
+    )) %>%
+    tableau_extension()
+}

--- a/inst/examples/stringutils/plumber.R
+++ b/inst/examples/stringutils/plumber.R
@@ -39,4 +39,4 @@ function(req, res, value) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension

--- a/inst/rstudio/templates/project/resources/plumber.R
+++ b/inst/rstudio/templates/project/resources/plumber.R
@@ -21,4 +21,4 @@ function(str_value) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension

--- a/man/tableau_extension.Rd
+++ b/man/tableau_extension.Rd
@@ -4,14 +4,14 @@
 \alias{tableau_extension}
 \title{Make an existing Plumber API compliant as a Tableau Analytics Extension}
 \usage{
-tableau_extension(warnings = TRUE)
+tableau_extension(pr)
 }
 \arguments{
-\item{warnings}{Whether or not to provide warnings about non-Tableau compliant
-endpoints.}
+\item{pr}{A plumber router}
 }
 \value{
-A function that can be used with \code{#* @plumber}
+A modified plumber router that functions as a Tableau Analytics
+Extension
 }
 \description{
 Make an existing Plumber API compliant as a Tableau Analytics Extension
@@ -29,7 +29,7 @@ function(req, res) {
 }
 
 #* @plumber
-tableau_extension()
+tableau_extension
 }
 
 }

--- a/man/tableau_handler.Rd
+++ b/man/tableau_handler.Rd
@@ -18,7 +18,7 @@ optional, then its data type should be followed by \verb{?}, like
 
 \item{return}{A string indicating the data type that will be returned from
 \code{func} (\code{"character"}, \code{"logical"}, \code{"numeric"}, or \code{"integer"}); or, a
-specification object created by \code{\link[=arg_spec]{arg_spec()}}.}
+specification object created by \code{\link[=return_spec]{return_spec()}}.}
 
 \item{func}{A function to be used as the handler function. Code in the body
 of the function will automatically be able to access Tableau request args

--- a/man/tableau_invoke.Rd
+++ b/man/tableau_invoke.Rd
@@ -7,7 +7,7 @@
 tableau_invoke(pr, script, ..., .toJSON_args = NULL, .quiet = FALSE)
 }
 \arguments{
-\item{pr}{Either a \code{\link[=tableau_extension]{tableau_extension()}} style Plumber router object, or, the
+\item{pr}{Either a \link{tableau_extension} style Plumber router object, or, the
 filename of a plumber.R that implements a Tableau extension.}
 
 \item{script}{The script string that identifies the plumber route to invoke.

--- a/tests/testthat/test-tableau_handler.R
+++ b/tests/testthat/test-tableau_handler.R
@@ -1,3 +1,5 @@
+library(plumber)
+
 test_that("tableau_handler warns on missing function params", {
   args <- list(foo = arg_spec("character"), bar = arg_spec("character"))
 
@@ -12,4 +14,13 @@ test_that("tableau_handler warns on missing function params", {
   expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, bar) {}))
   expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, foo, bar) {}), NA)
   expect_warning(tableau_handler(args = args, return = return_spec(), func = function(req, res, ...) {}), NA)
+})
+
+test_that("Infer tableau handler throws an error when Tableau args and return types aren't provided", {
+  expect_error(
+    pr() %>%
+      pr_post("/foo", function() "foo") %>%
+      tableau_extension(),
+    regexp = "^Tableau argument and return data types"
+  )
 })


### PR DESCRIPTION
This alters `tableau_extension()` to modify the router, rather than _returning a function to modify the router_. It also moves `warnings` to an option (`plumbertableau.warnings`). This doesn't alter the standard user experience that much (use `tableau_extension` instead of `tableau_extension()`) but it makes it much more intuitive to programmatically create Tableau extensions.

Closes #35 