### PR TITLE
pkgdown fix

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 
 # R chunks
-knitr::read_chunk(path = system.file("plumber", "capitalize", "plumber.R", package = "plumbertableau"),
+knitr::read_chunk(path = "inst/plumber/capitalize/plumber.R",
                   from = 9,
                   labels = "capitalize")
 ```

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 
-knitr::read_chunk(path = system.file("plumber", "capitalize", "plumber.R", package = "plumbertableau"),
+knitr::read_chunk(path = "../inst/plumber/capitalize/plumber.R",
                   from = 9,
                   labels = "capitalize")
 ```

--- a/vignettes/r-developer-guide.Rmd
+++ b/vignettes/r-developer-guide.Rmd
@@ -20,7 +20,7 @@ library(plumbertableau)
 set.seed(35487)
 
 # R chunks
-knitr::read_chunk(path = system.file("plumber", "loess", "plumber.R", package = "plumbertableau"),
+knitr::read_chunk(path = "../inst/plumber/loess/plumber.R",
                   labels = "loess")
 ```
 


### PR DESCRIPTION
This _should_ fix the `pkgdown` issues and cause the vignettes to properly build as articles. Once this goes through, we can modify the layout of the `pkgdown` site as we continue working on documentation in #49.