### PR TITLE
Just a small update to the DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,22 @@
 Package: plumbertableau
 Type: Package
-Title: Create Tableau Analytics Extension API Compliant Plumber APIs
+Title: Extend Tableau with Plumber APIs
 Version: 0.1.0.9999
 Authors@R: c(
-    person("James", "Blair", , "james@rstudio.com", c("aut", "cre")),
-    person(family = "RStudio", role = c("cph", "fnd")),
-    person(family = "Tableau", role = c("cph"))
+    person("James", "Blair", email = "james@rstudio.com", role = c("aut", "cre")),
+    person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut")),
+    person("Toph", "Allen", email = "toph@rstudio.com", role = "aut"),
+    person("Bill", "Sager", email = "bill.sager@rstudio.com", role = "aut"),
+    person("RStudio", role = c("cph", "fnd")),
+    person("Tableau", role = c("cph"))
     )
-Description: The Tableau Analytics Extension API allows Tableau to be extended
-    to external services. This package provides helpers for creating Plumber
-    APIs that properly function as Tableau Analytics Extensions.
+Description: Build and publish Plumber APIs that are compatible with the
+    Tableau Analytics Extension API. Using annotations in R comments, extensions
+    will respond to requests from Tableau, allowing you to call R code from
+    Tableau workbooks.
 License: MIT + file LICENSE
 URL: https://rstudio.github.io/plumbertableau/, https://github.com/rstudio/plumbertableau
+BugReports: https://github.com/rstudio/plumbertableau/issues
 Encoding: UTF-8
 LazyData: true
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: plumbertableau
 Type: Package
-Title: Extend Tableau with Plumber APIs
+Title: Turn 'Plumber' APIs into 'Tableau' Extensions
 Version: 0.1.0.9999
 Authors@R: c(
     person("James", "Blair", email = "james@rstudio.com", role = c("aut", "cre")),
@@ -10,10 +10,10 @@ Authors@R: c(
     person("RStudio", role = c("cph", "fnd")),
     person("Tableau", role = c("cph"))
     )
-Description: Build and publish Plumber APIs that are compatible with the
-    Tableau Analytics Extension API. Using annotations in R comments, extensions
-    will respond to requests from Tableau, allowing you to call R code from
-    Tableau workbooks.
+Description: Build 'Plumber' APIs that can be used in 'Tableau' workbooks.
+    Annotations in R comments allow APIs to conform to the 'Tableau Analytics
+    Extension' specification, so that R code can be used to power 'Tableau'
+    workbooks.
 License: MIT + file LICENSE
 URL: https://rstudio.github.io/plumbertableau/, https://github.com/rstudio/plumbertableau
 BugReports: https://github.com/rstudio/plumbertableau/issues

--- a/man/plumbertableau-package.Rd
+++ b/man/plumbertableau-package.Rd
@@ -4,27 +4,36 @@
 \name{plumbertableau-package}
 \alias{plumbertableau}
 \alias{plumbertableau-package}
-\title{plumbertableau: Create Tableau Analytics Extension API Compliant Plumber APIs}
+\title{plumbertableau: Extend Tableau with Plumber APIs}
 \description{
-The Tableau Analytics Extension API allows Tableau to be extended
-    to external services. This package provides helpers for creating Plumber
-    APIs that properly function as Tableau Analytics Extensions.
+Build and publish Plumber APIs that are compatible with the
+    Tableau Analytics Extension API. Using annotations in R comments, extensions
+    will respond to requests from Tableau, allowing you to call R code from
+    Tableau workbooks.
 }
 \seealso{
 Useful links:
 \itemize{
   \item \url{https://rstudio.github.io/plumbertableau/}
   \item \url{https://github.com/rstudio/plumbertableau}
+  \item Report bugs at \url{https://github.com/rstudio/plumbertableau/issues}
 }
 
 }
 \author{
 \strong{Maintainer}: James Blair \email{james@rstudio.com}
 
+Authors:
+\itemize{
+  \item Joe Cheng \email{joe@rstudio.com}
+  \item Toph Allen \email{toph@rstudio.com}
+  \item Bill Sager \email{bill.sager@rstudio.com}
+}
+
 Other contributors:
 \itemize{
-  \item  RStudio [copyright holder, funder]
-  \item  Tableau [copyright holder]
+  \item RStudio [copyright holder, funder]
+  \item Tableau [copyright holder]
 }
 
 }


### PR DESCRIPTION
I don't necessarily love the `Title` field, but it's super concise and not redundant with the package name or the `Description` field.

There were no major changes other than these that I could find from reviewing the CRAN submission checklist or CRAN Repository Policy.