### PR TITLE
Release 0.1.0

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-08-04.
-Once it is accepted, delete this file and tag the release (commit a3f05c2).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plumbertableau
 Type: Package
 Title: Turn 'Plumber' APIs into 'Tableau' Extensions
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("James", "Blair", email = "james@rstudio.com", role = c("aut", "cre")),
     person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# plumbertableau 0.1.0.9000
+
 # plumbertableau 0.1.0
 
 * Initial package release


### PR DESCRIPTION
Housekeeping for moving on from the release of 0.1.0
Following the guidance provided here: https://r-pkgs.org/release.html#post-release