### PR TITLE
Match an arbitrary number of `\n`

### DIFF
--- a/tests/testthat/test-openapi.R
+++ b/tests/testthat/test-openapi.R
@@ -3,7 +3,7 @@ test_that("OpenAPI specification works", {
   spec <- pr$getApiSpec()
   for (path in spec$paths) {
     if (!is.null(path$post)) {
-      expect_match(path$post$requestBody$description, "^<h3>Tableau Request</h3>\n\n<p>This is a mock Tableau request.")
+      expect_match(path$post$requestBody$description, "^<h3>Tableau Request</h3>\n+<p>This is a mock Tableau request.")
     }
   }
 })


### PR DESCRIPTION
In the next version of **markdown**, it will generate only one `\n` instead of two. Adjust the test here so that it will work with any version of **markdown**.