### PR TITLE
Clear the CRAN note about unused imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Imports:
     stringi,
     markdown,
     urltools,
-    glue,
     utils,
     httr,
     knitr


### PR DESCRIPTION
https://cran.r-project.org/web/checks/check_results_plumbertableau.html

```
Version: 0.1.0
Check: dependencies in R code
Result: NOTE
    Namespace in Imports field not imported from: ‘glue’
     All declared Imports should be used.
```