### PR TITLE
In the next version of markdown, <h3> will have attributes

### DIFF
--- a/tests/testthat/test-openapi.R
+++ b/tests/testthat/test-openapi.R
@@ -3,7 +3,7 @@ test_that("OpenAPI specification works", {
   spec <- pr$getApiSpec()
   for (path in spec$paths) {
     if (!is.null(path$post)) {
-      expect_match(path$post$requestBody$description, "^<h3>Tableau Request</h3>\n+<p>This is a mock Tableau request.")
+      expect_match(path$post$requestBody$description, "^<h3[^>]*>Tableau Request</h3>\n+<p>This is a mock Tableau request.")
     }
   }
 })


### PR DESCRIPTION
Update the regex to allow for attributes.

@blairj09 Is there a chance that you could merge this PR and make a CRAN release at some point? Thanks!